### PR TITLE
Correct conditional call to useState and useEffect in BookDetail.js

### DIFF
--- a/src/components/BookDetails.js
+++ b/src/components/BookDetails.js
@@ -1,5 +1,5 @@
 import { Link, useParams } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { books } from "../data/books";
 import ProgressBar from "./ProgressBar/ProgressBar";
 import NotFoundPage from "./NotFound/NotFoundPage";
@@ -9,23 +9,18 @@ export default function BookDetails() {
 
   const validBookIds = Array.from({ length: 66 }, (_, i) => i + 1);
   const isValidBookIdPage = validBookIds.includes(parseInt(slug, 10));
-  if (!isValidBookIdPage) {
-    return <NotFoundPage />;
-  }
-
-  const book = books.find((item) => item.id == slug);
-  const chapters = Array.from(
-    { length: book.chapter },
-    (value, idx) => idx + 1
-  );
 
   const localStorageKey = book.title;
 
-  const [selecteds, setSelecteds] = useState(
-    localStorage.hasOwnProperty(localStorageKey)
+  // Use `useMemo` to memoize the initial state of `selecteds`
+  const initialSelecteds = useMemo(() => {
+    return localStorage.hasOwnProperty(localStorageKey)
       ? JSON.parse(localStorage.getItem(localStorageKey))
-      : []
-  );
+      : [];
+  }, [localStorageKey]);
+
+  const [selecteds, setSelecteds] = useState(initialSelecteds);
+
   const COLORS = {
     selected: "rgb(254 245 231)",
   };
@@ -54,7 +49,10 @@ export default function BookDetails() {
     (selecteds.length / book.chapter) * 100
   );
 
-  const [title, setTitle] = useState(book.title);
+  // Use `useMemo` to memoize the initial state of `title` (if needed)
+  const initialTitle = useMemo(() => book.title, [book]);
+
+  const [title, setTitle] = useState(initialTitle);
 
   useEffect(() => {
     document.title = book.title + " | Bible Track";
@@ -63,6 +61,16 @@ export default function BookDetails() {
   const handleRetourClick = () => {
     document.title = "Bible Track";
   };
+
+  if (!isValidBookIdPage) {
+    return <NotFoundPage />;
+  }
+  
+  const book = books.find((item) => item.id == slug);
+  const chapters = Array.from(
+    { length: book.chapter },
+    (value, idx) => idx + 1
+  );
 
   return (
     <>


### PR DESCRIPTION
## Fix React hook conditionally called

`useState` and `useEffect `had been called conditionally, leading to a React hook usage error.
This commit addresses the issue #28 by :

1. Using `useMemo `to store the initial states of `selecteds` and `title`, ensuring consistent rendering even when the component's logic changes

2. Moving the `useState` calls before the conditional rendering to ensure they are always rendered in the same order, preventing React hooks rule violation

3. Moving the `<NotFoundPage />` component and book/chapter mapping after the `useState` calls to avoid conditional rendering and potential performance issues

**Final result:**
![Screenshot 2024-08-27 134235](https://github.com/user-attachments/assets/a94ceb17-c2d1-464c-a5b5-bf060bae9a77)
