### PR TITLE
Main Progress Bar

### DIFF
--- a/src/components/BookList.js
+++ b/src/components/BookList.js
@@ -21,6 +21,7 @@ export default function BookList() {
           flexDirection: "column",
           alignItems: "center",
         }}
+        key={book.id}
       >
         <Link
           to={`/books/${book.id}`}

--- a/src/components/ProgressBar/GlobalProgressBar.js
+++ b/src/components/ProgressBar/GlobalProgressBar.js
@@ -7,18 +7,36 @@ function GlobalProgressBar() {
       acc + (JSON.parse(localStorage.getItem(bookTitle)) || []).length,
     0
   );
-  console.log("bookTitles", bookTitles)
+  console.log("bookTitles", bookTitles);
   const totalChap = books.reduce((acc, book) => acc + book.chapter, 0);
   const percentage = Math.round((chapitresLus * 100) / totalChap);
+  console.log("TatalChapters", totalChap);
+  const bookChap = books.map((book) => book.chapter);
+  console.log("bookChap", bookChap);
 
   return (
     <div className="container-progress">
       <p>{percentage}%</p>
-      <div className={`progress-bar-container`}>
-        <div
-          className={`progress-bar segment-read-color`}
-          style={{ width: `${percentage}%`  }}
-        ></div>
+
+      {/* Main container width based on total chapters */}
+      <div className="g-progress-bar-container" style={{ width: `${totalChap}px`, height: "1px" }}>
+        
+        {/* Use map() to iterate over books and generate progress bars */}
+        {books.map((book, index) => {
+          const readChapters = JSON.parse(localStorage.getItem(book.title)) || [];
+          const bookPercentage = Math.round((readChapters.length * 100) / book.chapter);
+          
+          console.log(`Read chapters for ${book.title}:`, readChapters);
+
+          return (
+            <div key={index} className="i-progress-bar-container" style={{ width: `${book.chapter}px` }}>
+              <div
+                className="i-progress-bar segment-read-color"
+                style={{ width: `${bookPercentage}%` }}
+              ></div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/ProgressBar/ProgressBar.css
+++ b/src/components/ProgressBar/ProgressBar.css
@@ -17,6 +17,31 @@
   /* margin-top: -1em; */
 }
 
+.i-progress-bar-container {
+  width: 80%;
+  height: 1rem;
+  background-color: #000;
+  overflow: hidden;
+  /* margin-top: -1em; */
+}
+
+.i-progress-bar-container:first-child {
+  border-radius: 5px 0px 0px 5px;
+}
+
+.i-progress-bar-container:last-child {
+  border-radius: 0px 5px 5px 0px;
+}
+
+.g-progress-bar-container {
+  height: 1rem;
+  background-color: #000;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  /* margin-top: -1em; */
+}
+
 .segment-read-color {
   background-color: #09f;
 }
@@ -26,6 +51,12 @@
   height: 100%;
   overflow: hidden;
   border-radius: 5px;
+}
+
+.i-progress-bar {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
 }
 
 .progress-bar>span {


### PR DESCRIPTION
### Add main progress bar
This update addresses issue #10 by enhancing the main progress bar to display the user's global progress

In the previous implementation, the main progress bar showed only the user's overall progress percentage. The goal was to extend this functionality, so the main progress bar reflects the progress of each book separately. To achieve this, I followed these steps:

- Make the width of the main progress bar based on the total number of chapters across all books.

- For each book, a custom progress bar is rendered inside the main bar. Each of these smaller bars visually represents the percentage of chapters completed for that specific book.

- The individual book progress bars are arranged inside the main bar using CSS Flexbox

Here is final look:

![image](https://github.com/user-attachments/assets/2a5e4635-b974-4341-9edc-e2b19f89cd8b)
